### PR TITLE
strict: Fix py3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 install:
   - pip install .

--- a/colander_tools/bytes.py
+++ b/colander_tools/bytes.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import base64
 
 from colander import SchemaType, null, Invalid, _
+from . import compat
 
 
 class AbstractEncodedBytes(SchemaType):
@@ -23,7 +24,7 @@ class AbstractEncodedBytes(SchemaType):
         if cstruct is null:
             return null
 
-        if not isinstance(cstruct, basestring):
+        if not isinstance(cstruct, compat.string_types):
             raise Invalid(node, _("must be a string"))
 
         return self.decoder(cstruct)

--- a/colander_tools/compat.py
+++ b/colander_tools/compat.py
@@ -4,8 +4,8 @@ PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 if PY2:
-    string_types = basestring,
-    text_type = unicode
+    string_types = basestring,   # noqa
+    text_type = unicode          # noqa
 else:
-    string_types = str,
-    text_type = str
+    string_types = str,          # noqa
+    text_type = str              # noqa

--- a/colander_tools/compat.py
+++ b/colander_tools/compat.py
@@ -1,0 +1,11 @@
+import sys
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+if PY2:
+    string_types = basestring,
+    text_type = unicode
+else:
+    string_types = str,
+    text_type = str

--- a/colander_tools/strict.py
+++ b/colander_tools/strict.py
@@ -4,6 +4,7 @@ A collection of strict types for Colander.
 """
 
 from colander import _, SchemaType, Invalid, null, Mapping as BaseMapping
+from . import compat
 
 
 class Number(SchemaType):
@@ -102,13 +103,13 @@ class String(SchemaType):
         if appstruct is null:
             return null
 
-        return unicode(appstruct)
+        return compat.text_type(appstruct)
 
     def deserialize(self, node, cstruct):
         if cstruct is null:
             return null
 
-        if isinstance(cstruct, basestring):
+        if isinstance(cstruct, compat.string_types):
             return cstruct
 
         raise Invalid(node, _('${val} is not a string', mapping={'val': cstruct}))

--- a/colander_tools/strict.py
+++ b/colander_tools/strict.py
@@ -21,13 +21,16 @@ class Number(SchemaType):
             raise Invalid(node, _('"${val}" is not a number', mapping={'val': appstruct}))
 
     def deserialize(self, node, cstruct):
-        if cstruct != 0 and not cstruct:
+        if cstruct is null:
             return null
 
         try:
-            return self.num(cstruct)
+            if isinstance(cstruct, self.num):
+                return self.num(cstruct)
         except Exception:
-            raise Invalid(node, _('"${val}" is not a number', mapping={'val': cstruct}))
+            pass
+
+        raise Invalid(node, _('"${val}" is not a number', mapping={'val': cstruct}))
 
 
 class Integer(Number):

--- a/colander_tools/test_strict.py
+++ b/colander_tools/test_strict.py
@@ -1,5 +1,6 @@
 import colander
 from colander_tools import strict
+import pytest
 
 
 def test_integer():
@@ -10,17 +11,11 @@ def test_integer():
     integer = strict.Integer().serialize({}, True)
     assert(integer == 1)
 
-    try:
+    with pytest.raises(colander.Invalid):
         integer = strict.Integer().serialize({}, "foo")
-        raise
-    except colander.Invalid:
-        pass
 
-    try:
+    with pytest.raises(colander.Invalid):
         integer = strict.Integer().serialize({}, {})
-        raise
-    except colander.Invalid:
-        pass
 
     # Deserialization
     integer = strict.Integer().deserialize({}, 1)
@@ -29,17 +24,11 @@ def test_integer():
     integer = strict.Integer().deserialize({}, True)
     assert(integer == 1)
 
-    try:
+    with pytest.raises(colander.Invalid):
         integer = strict.Integer().deserialize({}, "foo")
-        raise
-    except colander.Invalid:
-        pass
 
-    try:
+    with pytest.raises(colander.Invalid):
         integer = strict.Integer().deserialize({}, {})
-        raise
-    except colander.Invalid:
-        pass
 
 
 def test_float():
@@ -50,11 +39,8 @@ def test_float():
     float = strict.Float().serialize({}, True)
     assert(float == 1)
 
-    try:
+    with pytest.raises(colander.Invalid):
         float = strict.Float().serialize({}, "foo")
-        raise
-    except colander.Invalid:
-        pass
 
     # Deserialization
     float = strict.Float().deserialize({}, 4.5)
@@ -63,11 +49,8 @@ def test_float():
     float = strict.Float().deserialize({}, True)
     assert(float == 1)
 
-    try:
+    with pytest.raises(colander.Invalid):
         float = strict.Float().deserialize({}, "foo")
-        raise
-    except colander.Invalid:
-        pass
 
 
 def test_boolean():
@@ -116,23 +99,14 @@ def test_string():
     string = strict.String().deserialize({}, "foo")
     assert(string == "foo")
 
-    try:
+    with pytest.raises(colander.Invalid):
         string = strict.String().deserialize({}, True)
-        raise
-    except colander.Invalid:
-        pass
 
-    try:
+    with pytest.raises(colander.Invalid):
         string = strict.String().deserialize({}, 1)
-        raise
-    except colander.Invalid:
-        pass
 
-    try:
+    with pytest.raises(colander.Invalid):
         string = strict.String().deserialize({}, {})
-        raise
-    except colander.Invalid:
-        pass
 
 
 def test_mapping():
@@ -142,17 +116,11 @@ def test_mapping():
         foo = colander.SchemaNode(strict.String())
         bar = colander.SchemaNode(strict.String())
 
-    try:
+    with pytest.raises(colander.Invalid):
         Foo().deserialize({"foo": "bar"})
-        raise
-    except colander.Invalid:
-        pass
 
-    try:
+    with pytest.raises(colander.Invalid):
         Foo().deserialize({"bar": "foo"})
-        raise
-    except colander.Invalid:
-        pass
 
     correct = {"bar": "foo", "foo": "bar"}
     mapping = Foo().deserialize(correct)

--- a/colander_tools/test_strict.py
+++ b/colander_tools/test_strict.py
@@ -46,8 +46,8 @@ def test_float():
     float = strict.Float().deserialize({}, 4.5)
     assert(float == 4.5)
 
-    float = strict.Float().deserialize({}, True)
-    assert(float == 1)
+    with pytest.raises(colander.Invalid):
+        float = strict.Float().deserialize({}, True)
 
     with pytest.raises(colander.Invalid):
         float = strict.Float().deserialize({}, "foo")


### PR DESCRIPTION
The test coverage is super spotty, but the tests we have pass on Py3 now.
