### PR TITLE
Add the null.NullableSchema.

### DIFF
--- a/colander_tools/null.py
+++ b/colander_tools/null.py
@@ -1,5 +1,5 @@
 
-from colander import SchemaType, drop
+from colander import SchemaType, drop, null
 
 
 class NullType(SchemaType):
@@ -33,3 +33,34 @@ class IgnoreType(SchemaType):
 
     def deserialize(self, node, cstruct):
         return drop
+
+
+def NullableSchema(schema_cls):
+    def _serialize(self, appstruct=null):
+        # Replicate colander behavior w.r.t. default.
+        if appstruct is null:
+            appstruct = self.default
+
+        if appstruct is None:
+            return None
+
+        return schema_cls.serialize(self, appstruct)
+
+    def _deserialize(self, cstruct=null):
+        # Replicate colander behavior w.r.t. missing.
+        if cstruct is null:
+            cstruct = self.missing
+
+        if cstruct is None:
+            return None
+
+        return schema_cls.deserialize(self, cstruct)
+
+    return type(
+        "Nullable%s" % schema_cls.__name__,
+        (schema_cls, ),
+        {
+            "serialize": _serialize,
+            "deserialize": _deserialize,
+        }
+    )

--- a/colander_tools/test_null.py
+++ b/colander_tools/test_null.py
@@ -1,0 +1,27 @@
+import colander
+from colander_tools import null, serializable, strict
+
+
+def test_nullable_schema():
+    class MaybeNullSchema(colander.MappingSchema):
+        schema_type = strict.Mapping
+
+        foo = colander.SchemaNode(colander.String())
+
+    @serializable.serializable
+    class Definition(object):
+        class Schema(colander.MappingSchema):
+            schema_type = strict.Mapping
+
+            foo = null.NullableSchema(MaybeNullSchema)(
+                default=None,
+                missing=None,
+            )
+
+        def __init__(self, foo=None):
+            self.foo = foo
+
+    assert Definition.Schema().deserialize({"foo": {"foo": "bar"}}).foo["foo"] == "bar"
+    assert Definition.Schema().deserialize({}).foo is None
+    assert Definition.Schema().serialize(Definition(foo={"foo": "bar"}))["foo"]["foo"] == "bar"
+    assert Definition.Schema().serialize(Definition())["foo"] is None


### PR DESCRIPTION
This lets you have the equivalent of a NullableType, for SchemaNodes.
