### PR TITLE
Some python3 updates

### DIFF
--- a/colander_tools/bytes.py
+++ b/colander_tools/bytes.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 import base64
 
 from colander import SchemaType, null, Invalid, _
+import six
+
 from . import compat
 
 
@@ -15,8 +17,8 @@ class AbstractEncodedBytes(SchemaType):
         if appstruct is null:
             return null
 
-        if not isinstance(appstruct, str):
-            raise Invalid(node, _("must be a byte string"))
+        if not isinstance(appstruct, six.binary_type):
+            raise Invalid(node, _("{} must be a byte string ".format(type(appstruct),appstruct)))
 
         return self.encoder(appstruct)
 
@@ -24,8 +26,8 @@ class AbstractEncodedBytes(SchemaType):
         if cstruct is null:
             return null
 
-        if not isinstance(cstruct, compat.string_types):
-            raise Invalid(node, _("must be a string"))
+        if not isinstance(cstruct, compat.chars_type):
+            raise Invalid(node, _("{} must be a string".format(type(cstruct))))
 
         return self.decoder(cstruct)
 
@@ -41,10 +43,10 @@ class Base32Bytes(AbstractEncodedBytes):
 
 
 class Base64Bytes(AbstractEncodedBytes):
-    encoder = staticmethod(base64.standard_b64encode)
+    encoder = staticmethod(lambda p: base64.standard_b64encode(p).decode("ascii"))
     decoder = staticmethod(base64.standard_b64decode)
 
 
 class URLSafeBase64Bytes(AbstractEncodedBytes):
-    encoder = staticmethod(base64.urlsafe_b64encode)
+    encoder = staticmethod(lambda p: base64.urlsafe_b64encode(p).decode("ascii"))
     decoder = staticmethod(base64.urlsafe_b64decode)

--- a/colander_tools/compat.py
+++ b/colander_tools/compat.py
@@ -6,6 +6,8 @@ PY3 = sys.version_info[0] == 3
 if PY2:
     string_types = basestring,   # noqa
     text_type = unicode          # noqa
+    chars_type = str,
 else:
     string_types = str,          # noqa
     text_type = str              # noqa
+    chars_type = str, bytes,

--- a/colander_tools/mapping.py
+++ b/colander_tools/mapping.py
@@ -2,7 +2,7 @@
 import collections
 
 import colander
-
+import six
 
 class OrderedMapping(colander.Mapping):
     """A mapping that serializes to an ordered dict."""
@@ -90,7 +90,7 @@ class OpenMapping(colander.Mapping):
         error = None
         result = {}
 
-        for index, (k, v) in enumerate(value.iteritems()):
+        for index, (k, v) in enumerate(six.iteritems(value)):
             key_node = node["key"]
             value_node = node["value"].clone()
             value_node.name = k

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 -e .
+colander
+pytz

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,6 @@ setup(
     install_requires=[
         "colander",
         "pytz",
+        "six",
         ],
     )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -24,3 +24,4 @@ requirements-detector==0.5.1
 setoptconf==0.2.0
 six==1.10.0
 wrapt==1.10.8
+pytz


### PR DESCRIPTION
### base64 serializers/deserializers
there's some binary strings for internal state that are stored as b64 sequences. this involves strings of bytes ascii encoded.

Python 3 is more strictly accurate about what things are strings of bytes and what things are strings.

### misc syntax

also patch an iteritems with six.