### PR TITLE
Add python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ install:
   - pip install -r test-requirements.txt
 
 script:
-  - prospector --ignore-patterns='^(?!colander_tools)'
+  # Turning off prospector autodetect because, otherwise, it thinks Django is a dependency and fails.
+  - prospector --ignore-patterns='^(?!colander_tools)' --no-autodetect
   - py.test colander_tools

--- a/colander_tools/bytes.py
+++ b/colander_tools/bytes.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 import base64
 
 from colander import SchemaType, null, Invalid, _
+import six
+
 from . import compat
 
 
@@ -15,8 +17,8 @@ class AbstractEncodedBytes(SchemaType):
         if appstruct is null:
             return null
 
-        if not isinstance(appstruct, str):
-            raise Invalid(node, _("must be a byte string"))
+        if not isinstance(appstruct, six.binary_type):
+            raise Invalid(node, _("appstruct, currently type {}, must be a byte string ".format(type(appstruct))))
 
         return self.encoder(appstruct)  # noqa
 
@@ -25,7 +27,7 @@ class AbstractEncodedBytes(SchemaType):
             return null
 
         if not isinstance(cstruct, compat.string_types):
-            raise Invalid(node, _("must be a string"))
+            raise Invalid(node, _("cstruct, currently type {}, must be a string".format(type(cstruct))))
 
         return self.decoder(cstruct)  # noqa
 

--- a/colander_tools/mapping.py
+++ b/colander_tools/mapping.py
@@ -2,7 +2,7 @@
 import collections
 
 import colander
-
+import six
 
 class OrderedMapping(colander.Mapping):
     """A mapping that serializes to an ordered dict."""
@@ -89,7 +89,7 @@ class OpenMapping(colander.Mapping):
         error = None
         result = {}
 
-        for index, (k, v) in enumerate(value.iteritems()):
+        for index, (k, v) in enumerate(six.iteritems(value)):
             key_node = node["key"]
             value_node = node["value"].clone()
             value_node.name = k

--- a/colander_tools/strict.py
+++ b/colander_tools/strict.py
@@ -10,6 +10,8 @@ from . import compat
 class Number(SchemaType):
     """ Abstract base class for float, int, decimal """
 
+    # Initialising num to type(None) to fix a linting error.
+    num = type(None)
     num = None
 
     def serialize(self, node, appstruct):

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         ],
     keywords="",
     author="Platform.sh",
@@ -28,5 +29,7 @@ setup(
         "colander",
         "pytz",
         "netaddr",
+        "six",
     ],
 )
+

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
-prospector==1.2.0
+prospector==1.2.0 ; python_version < '3'
+prospector==1.3.1 ; python_version >= '3'
 pytest==5.4.3; python_version >= '3'
 pytest==4.6.11; python_version < '3'


### PR DESCRIPTION
Add python3 compatibility:
 * Python3 compatibility
 * Update prospector and fix prospector errors

How this has been tested
I have run the tests (py.test) using python2.7 and python3. Tests and prospector happy locally and in CI :)
Thank you very much!