### PR TITLE
Make all EncodedBytes implemetations py3 compatible

### DIFF
--- a/colander_tools/bytes.py
+++ b/colander_tools/bytes.py
@@ -32,21 +32,26 @@ class AbstractEncodedBytes(SchemaType):
         return self.decoder(cstruct)  # noqa
 
 
+# We need all encoded values to end up being strings so we can generate JSON, that is why they are decoded to
+# ascii - they are bs64 encoded strings, meaning they can always become ascii strings.
+# On the other hand, colander needs this to be byte strings, that is why we simply return bytes from the
+# decoder.
+
 class Base16Bytes(AbstractEncodedBytes):
-    encoder = staticmethod(base64.b16encode)
+    encoder = staticmethod(lambda b: base64.b16encode(b).decode("ascii"))
     decoder = staticmethod(base64.b16decode)
 
 
 class Base32Bytes(AbstractEncodedBytes):
-    encoder = staticmethod(base64.b32encode)
+    encoder = staticmethod(lambda b: base64.b32encode(b).decode("ascii"))
     decoder = staticmethod(base64.b32decode)
 
 
 class Base64Bytes(AbstractEncodedBytes):
-    encoder = staticmethod(base64.standard_b64encode)
+    encoder = staticmethod(lambda b: base64.standard_b64encode(b).decode("ascii"))
     decoder = staticmethod(base64.standard_b64decode)
 
 
 class URLSafeBase64Bytes(AbstractEncodedBytes):
-    encoder = staticmethod(base64.urlsafe_b64encode)
+    encoder = staticmethod(lambda b: base64.urlsafe_b64encode(b).decode("ascii"))
     decoder = staticmethod(base64.urlsafe_b64decode)

--- a/colander_tools/test_bytes.py
+++ b/colander_tools/test_bytes.py
@@ -1,0 +1,43 @@
+from colander_tools import bytes
+import pytest
+import sys
+
+@pytest.mark.skipif(sys.version_info < (3, 0), reason="requires python 3")
+def test_incompatible_types():
+    """
+    This test is only applicable to python3 code because strings and byte arrays are the
+    same thing in python2.
+    """
+    with pytest.raises(TypeError):
+        bytes.Base16Bytes.encoder(u"")
+    with pytest.raises(TypeError):
+        bytes.Base32Bytes.encoder(u"")
+    with pytest.raises(TypeError):
+        bytes.Base64Bytes.encoder(u"")
+    with pytest.raises(TypeError):
+        bytes.URLSafeBase64Bytes.encoder(u"")
+
+def test_Base16Bytes():
+    assert(bytes.Base16Bytes.encoder(b"") == u"")
+    assert(bytes.Base16Bytes.encoder(b"iamsometext") == u"69616D736F6D6574657874")
+    assert(bytes.Base16Bytes.decoder(u"69616D736F6D6574657874") == b"iamsometext")
+    assert(bytes.Base16Bytes.decoder(b"69616D736F6D6574657874") == b"iamsometext")
+
+def test_Base32Bytes():
+    assert(bytes.Base32Bytes.encoder(b"") == u"")
+    assert(bytes.Base32Bytes.encoder(b"iamsometext") == u"NFQW243PNVSXIZLYOQ======")
+    assert(bytes.Base32Bytes.decoder(u"NFQW243PNVSXIZLYOQ======") == b"iamsometext")
+    assert(bytes.Base32Bytes.decoder(b"NFQW243PNVSXIZLYOQ======") == b"iamsometext")
+
+def test_Base64Bytes():
+    assert(bytes.Base64Bytes.encoder(b"") == u"")
+    assert(bytes.Base64Bytes.encoder(b"iamsometext") == u"aWFtc29tZXRleHQ=")
+    assert(bytes.Base64Bytes.decoder(u"aWFtc29tZXRleHQ=") == b"iamsometext")
+    assert(bytes.Base64Bytes.decoder(b"aWFtc29tZXRleHQ=") == b"iamsometext")
+
+def test_URLSafeBase64Bytes():
+    assert(bytes.URLSafeBase64Bytes.encoder(b"") == u"")
+    assert(bytes.URLSafeBase64Bytes.encoder(b"url/?a=a&b=b") == u"dXJsLz9hPWEmYj1i")
+    assert(bytes.Base64Bytes.decoder(u"dXJsLz9hPWEmYj1i") == b"url/?a=a&b=b")
+    assert(bytes.Base64Bytes.decoder(b"dXJsLz9hPWEmYj1i") == b"url/?a=a&b=b")
+    


### PR DESCRIPTION
Esure that all the EncodedBytes implentations (Base16, Base32, Base64
and URLSafe) work with python 3 ensuring that:
* Encoders always return ascii strings instead of bytes, so we can
continue building JSON.
* Decoders continue returning byte arrays so we keep colander happy.
* Add unit tests for both cases.

This has been tested with foundation-schema, running the tests with this changes in both, py2 and py3.