### PR TITLE
pin colander < 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url="https://github.com/platformsh/colander-tools",
     packages=find_packages(),
     install_requires=[
-        "colander",
+        "colander < 2",
         "pytz",
         "netaddr",
         "six",


### PR DESCRIPTION
With the recent release of Colander 2.0, we need the current colander-tools version to pin colander < 2 because of a `colander.Mapping._impl()` signature change (it now takes 5 params instead of 4), as well as a dropped support for python <= 3.6.