### PR TITLE
fix: support colander 2

### DIFF
--- a/colander_tools/mapping.py
+++ b/colander_tools/mapping.py
@@ -78,12 +78,22 @@ class OrderedMapping(colander.Mapping):
         return self.__impl(node, cstruct, callback, serializing=False, unknown=self.unknown)
 
 
+unset = object()
+
+
 class OpenMapping(colander.Mapping):
     """
     A mapping where the keys are free-form and the values a specific type.
     """
 
-    def _impl(self, node, value, callback):
+    def _impl(self, node, value, callback, default_or_missing=unset):
+        # default_or_missing is used to specify whether this call is happening
+        # during serialization or deserialization, so that the validation can
+        # correctly choose between the default or missing attributes. Before
+        # colander 2.0, the default attribute was incorrectly used for both
+        # directions. Because OpenMapping doesn't validate the presence of
+        # specific keys, default and missing are both ignored, and the
+        # default_or_missing argument doesn't need to be used.
         value = self._validate(node, value)
 
         error = None
@@ -109,6 +119,8 @@ class OpenMapping(colander.Mapping):
 
 
 class SortedOpenMapping(OpenMapping):
-    def _impl(self, node, value, callback):
-        result = OpenMapping._impl(self, node, value, callback)
+    def _impl(self, node, value, callback, default_or_missing=unset):
+        result = OpenMapping._impl(
+            self, node, value, callback, default_or_missing
+        )
         return collections.OrderedDict(sorted(result.items()))

--- a/colander_tools/test_mapping.py
+++ b/colander_tools/test_mapping.py
@@ -1,0 +1,43 @@
+import colander
+from colander_tools import mapping, serializable, strict
+from collections import OrderedDict
+
+def test_open_mapping():
+    @serializable.serializable
+    class Definition(object):
+        class Schema(colander.MappingSchema):
+            schema_type = strict.Mapping
+
+            foo = colander.SchemaNode(
+                mapping.OpenMapping(),
+                colander.SchemaNode(colander.String(), name="key"),
+                colander.SchemaNode(strict.Integer(), name="value"),
+            )
+
+        def __init__(self, foo):
+            self.foo = foo
+
+    assert Definition.Schema().deserialize({"foo": {"a": 42}}).foo == {"a": 42}
+    assert Definition.Schema().serialize(Definition(foo={"mykey": 1234})) == {"foo": {"mykey": 1234}}
+
+
+
+def test_sorted_open_mapping():
+    @serializable.serializable
+    class Definition(object):
+        class Schema(colander.MappingSchema):
+            schema_type = strict.Mapping
+
+            foo = colander.SchemaNode(
+                mapping.SortedOpenMapping(),
+                colander.SchemaNode(colander.String(), name="key"),
+                colander.SchemaNode(strict.Integer(), name="value"),
+            )
+
+        def __init__(self, foo):
+            self.foo = foo
+
+    deserialized = Definition.Schema().deserialize({"foo": {"a": 42}}).foo
+    assert deserialized == {"a": 42}
+    assert isinstance(deserialized, OrderedDict)
+    assert Definition.Schema().serialize(Definition(foo={"mykey": 1234})) == {"foo": {"mykey": 1234}}

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url="https://github.com/platformsh/colander-tools",
     packages=find_packages(),
     install_requires=[
-        "colander < 2",
+        "colander >= 2, < 3",
         "pytz",
         "netaddr",
         "six",


### PR DESCRIPTION
Colander 2 introduced a extra argument to `colander.Mapping._impl` function (from https://github.com/Pylons/colander/pull/264), which break the `OpenMapping` and `SortedOpenMapping` subclasses from colander-tools.

This add the missing argument, as well
as a couple of tests to know about it if it ever happen again.